### PR TITLE
Basic group mint/redemption test framework utilizing simple flow matrix generator.

### DIFF
--- a/src/core-members-group/CMGHandler.sol
+++ b/src/core-members-group/CMGHandler.sol
@@ -206,11 +206,7 @@ abstract contract CMGHandler is CirclesCoreAddresses, ERC1155Holder, ICMGHandler
     /// @dev Reads the current conversion amount and beneficiary from transient storage
     /// @return ongoingConversion The amount of the ongoing conversion, or 0 if none is active
     /// @return beneficiary The address of the beneficiary for the ongoing conversion
-    function _expectingConversionReturn()
-        internal
-        view
-        returns (uint256 ongoingConversion, address beneficiary)
-    {
+    function _expectingConversionReturn() internal view returns (uint256 ongoingConversion, address beneficiary) {
         bytes32 conversionSlot = CONVERSION_SLOT;
         bytes32 beneficiarySlot = BENEFICIARY_SLOT;
 

--- a/src/core-members-group/CoreMembersGroup.sol
+++ b/src/core-members-group/CoreMembersGroup.sol
@@ -62,7 +62,7 @@ contract CoreMembersGroup is
 
     /// @notice Only the Circles Hub can call this function
     modifier onlyHub() {
-        if (msg.sender != address(hub))  {
+        if (msg.sender != address(hub)) {
             revert CMGroupOnlyHub();
         }
         _;
@@ -70,7 +70,7 @@ contract CoreMembersGroup is
 
     /// @notice Only the Circles Hub or group Treasury can call this function
     modifier onlyHubOrTreasury() {
-        if (msg.sender != address(hub) && msg.sender != address(standardTreasury))  {
+        if (msg.sender != address(hub) && msg.sender != address(standardTreasury)) {
             revert CMGroupOnlyHubOrTreasury();
         }
         _;

--- a/test/CMGMintRedemptionFlow.t.sol
+++ b/test/CMGMintRedemptionFlow.t.sol
@@ -1,0 +1,322 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.28;
+
+import "forge-std/Test.sol";
+import "forge-std/StdCheats.sol";
+import "circles-contracts-v2/hub/Hub.sol";
+import "src/core-members-group/CoreMembersGroup.sol";
+import "src/core-members-group/helpers/CMGroupDeployer.sol";
+import {FlowMatrixGenerator} from "test/helpers/FlowMatrixGenerator.sol";
+import "circles-contracts-v2/hub/TypeDefinitions.sol";
+
+/// @dev Need to move from fork into mock mode. Mock mode requires HubMock and StandardTreasuryMock, specific requirements will be added later.
+contract CMGMintRedemptionFlowTest is Test, FlowMatrixGenerator {
+    address deployer = makeAddr("deployer");
+    // Fork id for Gnosis chain
+    uint256 gnosisFork;
+
+    // Hub instance (the fork uses the real deployed Hub)
+    Hub hub = Hub(HUB);
+    // StandardTreasury instance (interface declared inside src/circles/IStandardTreasury; inhereted by CoreMembersGroup).
+    IStandardTreasury standardTreasury = IStandardTreasury(address(0x08F90aB73A515308f03A718257ff9887ED330C6e));
+
+    // Deployer for CoreMembersGroup
+    CMGroupDeployer cmgDeployer;
+
+    // The deployed CoreMembersGroup proxy (for our test group)
+    address groupProxy;
+    CoreMembersGroup coreMembersGroup;
+    uint256 groupTokenId;
+    address vault;
+
+    uint64 today;
+    address mintHandler;
+    address redemptionHandler;
+
+    function setUp() public {
+        // Fork Gnosis chain using RPC URL in environment variable (e.g., GNOSIS_RPC)
+        string memory rpcUrl = vm.envString("GNOSIS_RPC");
+        gnosisFork = vm.createFork(rpcUrl);
+        vm.selectFork(gnosisFork);
+
+        // Deploy the CMGroupDeployer (which deploys the CoreMembersGroup master copy)
+        cmgDeployer = new CMGroupDeployer();
+
+        // setup Hub today
+        today = hub.day(block.timestamp);
+
+        // Deploy a CoreMembersGroup instance using the deployer.
+        // In our deployer, the createCMGroup() function requires:
+        // _service, _name, _symbol, _metadataDigest.
+        address service = makeAddr("service");
+        address[] memory _initialConditions;
+        string memory groupName = "TestGroup";
+        string memory groupSymbol = "TG";
+        bytes32 metadataDigest = keccak256(abi.encodePacked("metadata"));
+
+        // Let the deployer create the group; msg.sender in this call will be the group owner.
+        vm.prank(deployer);
+        groupProxy = cmgDeployer.createCMGroup(service, _initialConditions, groupName, groupSymbol, metadataDigest);
+        coreMembersGroup = CoreMembersGroup(groupProxy);
+        groupTokenId = uint256(uint160(address(coreMembersGroup)));
+        mintHandler = coreMembersGroup.mintHandler();
+        redemptionHandler = coreMembersGroup.redemptionHandler();
+
+        // Now the CoreMembersGroup is deployed and registered in the Hub.
+        // Optionally, call functions to set additional parameters on the group.
+    }
+
+    // -------------------------------------------------------------------------
+    // Test Flow 1: Group Mint via operateFlowMatrix (Single collateral)
+    // -------------------------------------------------------------------------
+    function testGroupMintSingleFlow(uint256 totalAmount) public {
+        // Generate flow matrix based on mint handler as path destination and fuzzed: amount.
+        (
+            address sourceAvatar,
+            address[] memory flowVertices,
+            TypeDefinitions.FlowEdge[] memory flowEdges,
+            TypeDefinitions.Stream[] memory streams,
+            uint256[] memory redemptionIds,
+            uint256[] memory redemptionAmounts,
+            bytes memory packedCoordinates
+        ) = generateFlowMatrix(
+            totalAmount, // min 100, max 10_000
+            1, // one terminal edge, equal one collateral id
+            today, // from block state
+            [groupProxy, mintHandler] // testing constants: group and mintHandler
+        );
+
+        // Sanity check single flow - single collateral
+        assertEq(redemptionIds.length, 1, "Sanity check failed: generateFlowMatrix");
+        assertEq(redemptionAmounts.length, 1, "Sanity check failed: generateFlowMatrix");
+
+        // Hub calls the appropriate handler (mintHandler) as destination.
+        // Impersonate source avatar to call the operateFlowMatrix function.
+        vm.prank(sourceAvatar);
+        hub.operateFlowMatrix(flowVertices, flowEdges, streams, packedCoordinates);
+
+        // At this point, the Hub (via the mintHandler) should have minted group CRC (gCRC)
+        // and transferred them to the source avatar.
+        // Check that source avatar now has a balance of group CRC.
+        uint256 sourceAvatarBalance = hub.balanceOf(sourceAvatar, groupTokenId);
+        assertEq(
+            sourceAvatarBalance,
+            _polishFuzzedTotalAmount(totalAmount),
+            "Source avatar should receive total amount of group CRC"
+        );
+
+        // As we are testing against groups utilizing StandardTreasury, we can have extra effect check - collateral balance of vault.
+        // Get vault
+        vault = standardTreasury.vaults(groupProxy);
+        // Check single collateral balance of vault
+        assertEq(
+            redemptionAmounts[0],
+            hub.balanceOf(vault, redemptionIds[0]),
+            "Collateral balance hold by vault does not match"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Test Flow 2: Batch Group Mint Flow (multiple collaterals)
+    // -------------------------------------------------------------------------
+    function testGroupMintBatchFlow(uint256 totalAmount, uint256 numberOfTerminatedEdges) public {
+        // Generate flow matrix based on mint handler as path destination and fuzzed: amount and number of terminal edges,
+        // which are in range from 1 to 10. 3 intermidiate vertices per flow.
+        (
+            address sourceAvatar,
+            address[] memory flowVertices,
+            TypeDefinitions.FlowEdge[] memory flowEdges,
+            TypeDefinitions.Stream[] memory streams,
+            uint256[] memory redemptionIds,
+            uint256[] memory redemptionAmounts,
+            bytes memory packedCoordinates
+        ) = generateFlowMatrix(
+            totalAmount, // min 100, max 10_000
+            numberOfTerminatedEdges, // fuzz from 1 to 10, also equal number of collateral ids for now
+            today, // from block state
+            [groupProxy, mintHandler] // constants: group and mintHandler
+        );
+
+        // Hub calls the appropriate handler (mintHandler) as destination.
+        // Impersonate source avatar to call the operateFlowMatrix function.
+        vm.prank(sourceAvatar);
+        hub.operateFlowMatrix(flowVertices, flowEdges, streams, packedCoordinates);
+
+        // At this point, the Hub (via the mintHandler) should have minted group CRC (gCRC)
+        // and transferred them to the source avatar.
+        // Check that source avatar now has a balance of group CRC.
+        uint256 sourceAvatarBalance = hub.balanceOf(sourceAvatar, groupTokenId);
+        assertEq(
+            sourceAvatarBalance,
+            _polishFuzzedTotalAmount(totalAmount),
+            "Source avatar should receive total amount of group CRC"
+        );
+
+        // As we are testing against groups utilizing StandardTreasury, we can have extra effect check - collateral balances of vault.
+        // Get vault
+        vault = standardTreasury.vaults(groupProxy);
+        // Check collateral balances of vault
+        for (uint256 i; i < redemptionIds.length;) {
+            assertEq(
+                redemptionAmounts[i],
+                hub.balanceOf(vault, redemptionIds[i]),
+                "Collateral balances hold by vault does not match"
+            );
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Test Flow 3: Redemption Flow
+    // -------------------------------------------------------------------------
+    function testGroupRedemptionFlow(uint256 totalAmount, uint256 numberOfTerminatedEdges) public {
+        // Generate flow matrix based on mint handler as path destination and fuzzed: amount and number of terminal edges,
+        // which are in range from 1 to 10. 3 intermidiate vertices per flow.
+        (
+            address sourceAvatar,
+            address[] memory flowVertices,
+            TypeDefinitions.FlowEdge[] memory flowEdges,
+            TypeDefinitions.Stream[] memory streams,
+            uint256[] memory redemptionIds,
+            uint256[] memory redemptionAmounts,
+            bytes memory packedCoordinates
+        ) = generateFlowMatrix(
+            totalAmount, // min 100, max 10_000
+            numberOfTerminatedEdges, // fuzz from 1 to 10, also equal number of collateral ids for now
+            today, // from block state
+            [groupProxy, mintHandler] // constants: group and mintHandler
+        );
+
+        // Hub calls the appropriate handler (mintHandler) as destination.
+        // Impersonate source avatar to call the operateFlowMatrix function.
+        vm.prank(sourceAvatar);
+        hub.operateFlowMatrix(flowVertices, flowEdges, streams, packedCoordinates);
+
+        // At this point, the Hub (via the mintHandler) should have minted group CRC (gCRC)
+        // and transferred them to the source avatar.
+
+        // At the same time collateral should be holded by either group treasury or vault (in case StandardTreasury).
+
+        // Now source avatar friend should call operateFlowMatrix with crafted redemption data and redemption handler as destination.
+        // Lets craft input for this call.
+        // TODO: implement simple generateFlowMatrix function for such case (without group trust collateral and with data for stream)
+        // TODO: even better to refactor existing one into more generic, so it generates matrix flow for such case - one terminated edge:
+        //       id - groupCRC, from - source avatar, to - redemptionHandler; and few intermediate edges in one stream. kind of insert terminated id and from.
+        // temporary build simple stream with one flow
+        address sourceAvatarFriend = address(uint160(sourceAvatar) - MAX_ADDRESS_OFFSET);
+        // set friend state
+        _setSourceState(sourceAvatarFriend, today, _polishFuzzedTotalAmount(totalAmount));
+        // set trust connection
+        _setTrust(sourceAvatar, sourceAvatarFriend);
+        flowVertices = new address[](4); // friend, source, group, redemptionHandler
+        flowVertices[0] = sourceAvatarFriend;
+        flowVertices[1] = sourceAvatar;
+        flowVertices[2] = groupProxy;
+        flowVertices[3] = redemptionHandler;
+        uint16[] memory indexes;
+        (flowVertices, indexes) = sortWithMapping(flowVertices);
+        {
+            // generate packedCoordinates
+            uint16[] memory coords = new uint16[](6); // 2 edges: from friend to source, from source to redemptionHandler
+            coords[0] = indexes[0]; // id   (edge 0)
+            coords[1] = indexes[0]; // from (edge 0)
+            coords[2] = indexes[1]; // to   (edge 0)
+            coords[3] = indexes[2]; // id   (edge 1)
+            coords[4] = indexes[1]; // from (edge 1)
+            coords[5] = indexes[3]; // to   (edge 1)
+            packedCoordinates = _packCoordinates(coords);
+        }
+        {
+            // generate flow edges
+            flowEdges = new TypeDefinitions.FlowEdge[](2);
+            flowEdges[0] =
+                TypeDefinitions.FlowEdge({streamSinkId: 0, amount: uint192(_polishFuzzedTotalAmount(totalAmount))});
+            flowEdges[1] =
+                TypeDefinitions.FlowEdge({streamSinkId: 1, amount: uint192(_polishFuzzedTotalAmount(totalAmount))});
+        }
+        {
+            // generate streams
+            streams = new TypeDefinitions.Stream[](1);
+            // As we are testing against groups utilizing StandardTreasury. Lets try to specify our redemption intent.
+
+            // Encode redemption policy data.
+            bytes memory userData =
+                abi.encode(BaseMintPolicyDefinitions.BaseRedemptionPolicy(redemptionIds, redemptionAmounts));
+            // Pack into Metadata struct (similar encoding as in protocol contracts).
+            bytes32 METADATATYPE_GROUPREDEEM = keccak256("CIRCLESv2:RESERVED_DATA:CirclesGroupRedeem");
+            bytes memory redemptionData = abi.encode(METADATATYPE_GROUPREDEEM, "", userData);
+            streams[0] = TypeDefinitions.Stream({
+                sourceCoordinate: indexes[0],
+                flowEdgeIds: new uint16[](1),
+                data: redemptionData // use redemption data to tell redemptionHandler what collateral is requested
+            });
+            streams[0].flowEdgeIds[0] = uint16(1);
+        }
+
+        // Now source avatar friend is ready to call operateFlowMatrix with crafted input.
+        vm.prank(sourceAvatarFriend);
+        hub.operateFlowMatrix(flowVertices, flowEdges, streams, packedCoordinates);
+
+        // After redemption, source avatar friend should have received collateral tokens.
+        // Check the collateral balance.
+        for (uint256 i; i < redemptionIds.length;) {
+            assertEq(
+                redemptionAmounts[i],
+                hub.balanceOf(sourceAvatarFriend, redemptionIds[i]),
+                "Collateral balances are not received by source avatar friend"
+            );
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    // TODO: for next redemption flow test we need to set extra collateral (attempt to redeem different).
+
+    // Internal helpers
+
+    /// @notice Sorts an array of addresses in ascending order
+    ///         and returns both the sorted array and a mapping (as an array)
+    ///         that indicates the original index for each sorted element.
+    /// @param arr The array of addresses to sort.
+    /// @return sortedAddresses The sorted array of addresses.
+    /// @return indexes An array where each element is the original index
+    ///         of the corresponding address in the sorted array.
+    function sortWithMapping(address[] memory arr)
+        public
+        pure
+        returns (address[] memory sortedAddresses, uint16[] memory indexes)
+    {
+        // Initialize the indexes array to track original positions.
+        // Each position i starts with the value i.
+        indexes = new uint16[](arr.length);
+        for (uint16 i; i < arr.length;) {
+            indexes[i] = i;
+            unchecked {
+                ++i;
+            }
+        }
+
+        // We'll perform a bubble sort on the addresses array.
+        // As we swap addresses, we swap the indexes as well.
+        for (uint256 i = 0; i < arr.length; i++) {
+            for (uint256 j = 0; j < arr.length - i - 1; j++) {
+                // Compare addresses directly (addresses are comparable)
+                if (arr[j] > arr[j + 1]) {
+                    // Swap addresses
+                    address temp = arr[j];
+                    arr[j] = arr[j + 1];
+                    arr[j + 1] = temp;
+
+                    // Swap corresponding indexes to maintain mapping
+                    uint16 tempIndex = indexes[j];
+                    indexes[j] = indexes[j + 1];
+                    indexes[j + 1] = tempIndex;
+                }
+            }
+        }
+        return (arr, indexes);
+    }
+}

--- a/test/CMGRedemptionHandler.t.sol
+++ b/test/CMGRedemptionHandler.t.sol
@@ -7,7 +7,7 @@ import {Vm} from "forge-std/Vm.sol";
 import {IERC1155} from "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
 
 import {CMGroupDeployer} from "src/core-members-group/helpers/CMGroupDeployer.sol";
-import {CoreMembersGroup } from "src/core-members-group/CoreMembersGroup.sol";
+import {CoreMembersGroup} from "src/core-members-group/CoreMembersGroup.sol";
 import {CMGRedemptionHandler} from "src/core-members-group/CMGRedemptionHandler.sol";
 import {IHub} from "src/circles/IHub.sol";
 
@@ -51,16 +51,10 @@ contract CirclesBackingFactoryTest is Test {
         vm.recordLogs();
         // deploy implementaion (from EOA)
         vm.prank(ADMIN);
-        cmGroup = deployerHelperContract.createCMGroup(
-            service,
-            _initialConditions,
-            "TestGroup",
-            "TG",
-            0x0
-        );
+        cmGroup = deployerHelperContract.createCMGroup(service, _initialConditions, "TestGroup", "TG", 0x0);
         Vm.Log[] memory logs = vm.getRecordedLogs();
 
-        for (uint i = 0; i < logs.length; i++) {
+        for (uint256 i = 0; i < logs.length; i++) {
             if (logs[i].topics[0] == keccak256("CMGroupCreated(address,address,address,address)")) {
                 mintHandler = address(uint160(uint256(logs[i].topics[3])));
                 redemptionHandler = abi.decode(logs[i].data, (address));
@@ -76,10 +70,7 @@ contract CirclesBackingFactoryTest is Test {
         uint256 MINT_AMOUNT = 3e18;
         vm.prank(groupMember);
         IERC1155(HUB_V2).safeTransferFrom(groupMember, mintHandler, uint256(uint160(groupMember)), MINT_AMOUNT, "");
-        assertEq(
-            IERC1155(HUB_V2).balanceOf(groupMember, uint256(uint160(cmGroup))),
-            MINT_AMOUNT
-        );
+        assertEq(IERC1155(HUB_V2).balanceOf(groupMember, uint256(uint160(cmGroup))), MINT_AMOUNT);
     }
 
     function test_automaticGroupTokenRedempton() public {
@@ -90,7 +81,7 @@ contract CirclesBackingFactoryTest is Test {
 
         vm.prank(groupMember);
         IERC1155(HUB_V2).safeTransferFrom(groupMember, redemptionHandler, uint256(uint160(cmGroup)), REDEEM_AMOUNT, "");
-        
+
         assertEq(
             initialMemberGroupTokenBalance - REDEEM_AMOUNT,
             IERC1155(HUB_V2).balanceOf(groupMember, uint256(uint160(cmGroup)))
@@ -103,7 +94,8 @@ contract CirclesBackingFactoryTest is Test {
 
         uint256 REDEEM_AMOUNT = 1e18;
 
-        (uint256[] memory ids, uint256[] memory amounts) = CMGRedemptionHandler(redemptionHandler).findCollateral(cmGroup, REDEEM_AMOUNT, false);
+        (uint256[] memory ids, uint256[] memory amounts) =
+            CMGRedemptionHandler(redemptionHandler).findCollateral(cmGroup, REDEEM_AMOUNT, false);
 
         vm.prank(groupMember);
         IERC1155(HUB_V2).setApprovalForAll(redemptionHandler, true);

--- a/test/helpers/FlowMatrixGenerator.sol
+++ b/test/helpers/FlowMatrixGenerator.sol
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.28;
+
+import {HubStorageWrites} from "./HubStorageWrites.sol";
+import "circles-contracts-v2/hub/TypeDefinitions.sol";
+
+contract FlowMatrixGenerator is HubStorageWrites {
+    uint256 internal constant MIN_TOTAL_AMOUNT = 100 ether;
+    uint256 internal constant MAX_TOTAL_AMOUNT = 10_000 ether;
+    uint256 internal constant MIN_TERMINATED_EDGES = 1;
+    uint256 internal constant MAX_TERMINATED_EDGES = 10;
+    uint160 internal constant MAX_ADDRESS_OFFSET = uint160(type(uint32).max);
+    uint160 internal constant MIN_ADDRESS_OFFSET = uint160(type(uint8).max);
+    uint256 internal constant NUMBER_VERTICES_PER_FLOW = 3;
+
+    function generateFlowMatrix(
+        uint256 totalAmount, // min 100, max 10_000
+        uint256 numberOfTerminatedEdges, // fuzz from 1 to 10, also equal number of collateral ids for now
+        uint64 lastUpdatedDay, // from block state
+        address[2] memory groupAndDestination // constants: group and mintHandler (next iteration: should be compatible mintHandler/redemptionHandler)
+    )
+        internal
+        returns (
+            address sourceAvatar,
+            address[] memory flowVertices,
+            TypeDefinitions.FlowEdge[] memory flowEdges,
+            TypeDefinitions.Stream[] memory streams,
+            uint256[] memory redemptionIds,
+            uint256[] memory redemptionAmounts,
+            bytes memory packedCoordinates
+        )
+    {
+        // polish fuzzing values
+        totalAmount = _polishFuzzedTotalAmount(totalAmount);
+        numberOfTerminatedEdges = _polishFuzzedNumberOfTerminatedEdges(numberOfTerminatedEdges);
+
+        // set value for sourceAvatar
+        sourceAvatar = address(uint160(groupAndDestination[1]) - MAX_ADDRESS_OFFSET);
+        // set source state
+        _setSourceState(sourceAvatar, lastUpdatedDay, totalAmount);
+
+        // lets for now for simplicity say that every flow has 4 edges in total:
+        // (init edge from - source, terminal edge to - destination, and 2 intermediate edges)
+        // later we will have randomness here and different number of edges at each flow and also common vertices at different flows
+        // so, it means that we need 3 intermidiate vertices per flow and source and destination vertices
+        uint256 numberOfVertices = numberOfTerminatedEdges * NUMBER_VERTICES_PER_FLOW + 2;
+
+        flowVertices = new address[](numberOfVertices);
+
+        // set source and destination vertices
+        flowVertices[0] = sourceAvatar;
+        flowVertices[numberOfVertices - 1] = groupAndDestination[1];
+
+        // generate vertices
+        // start after source and end before destination
+        for (uint160 i = 1; i < numberOfVertices - 1;) {
+            // generate vertix
+            address vertix = address(uint160(sourceAvatar) + MIN_ADDRESS_OFFSET * i);
+            // register vertix as human
+            _registerHuman(vertix);
+            flowVertices[i] = vertix;
+
+            unchecked {
+                ++i;
+            }
+        }
+
+        uint16[] memory coords;
+        {
+            uint256 numEdges = numberOfTerminatedEdges * (NUMBER_VERTICES_PER_FLOW + 1);
+            coords = new uint16[](3 * numEdges);
+            flowEdges = new TypeDefinitions.FlowEdge[](numEdges);
+        }
+
+        // for now have only 1 stream
+        streams = new TypeDefinitions.Stream[](1);
+        streams[0] = TypeDefinitions.Stream({
+            sourceCoordinate: uint16(0),
+            flowEdgeIds: new uint16[](numberOfTerminatedEdges),
+            data: ""
+        });
+        redemptionIds = new uint256[](numberOfTerminatedEdges);
+        redemptionAmounts = new uint256[](numberOfTerminatedEdges);
+        uint256[] memory flowAmounts = _generateFlowAmounts(totalAmount, numberOfTerminatedEdges);
+
+        // generate edges
+        // iterate through flows
+        for (uint256 i; i < numberOfTerminatedEdges;) {
+            // iterate through flow edges
+            for (uint256 k; k < NUMBER_VERTICES_PER_FLOW + 1;) {
+                uint256 index = i * (NUMBER_VERTICES_PER_FLOW + 1) + k;
+                _setEdgeState(lastUpdatedDay, flowVertices, flowAmounts[i], k, index - i);
+                // set coordinates
+                coords[3 * index + 0] = k != 0 ? uint16(index - i) : uint16(0); // id
+                coords[3 * index + 1] = k != 0 ? uint16(index - i) : uint16(0); // from
+                coords[3 * index + 2] =
+                    k != NUMBER_VERTICES_PER_FLOW ? uint16(index + 1 - i) : uint16(flowVertices.length - 1); // to
+                // set edge
+                flowEdges[index] = TypeDefinitions.FlowEdge({streamSinkId: 0, amount: uint192(flowAmounts[i])});
+                if (k == NUMBER_VERTICES_PER_FLOW) {
+                    // group trust collateral
+                    _setTrust(groupAndDestination[0], flowVertices[index - i]);
+                    flowEdges[index].streamSinkId = 1;
+                    redemptionIds[i] = uint256(uint160(flowVertices[index - i]));
+                    redemptionAmounts[i] = flowAmounts[i];
+                    streams[0].flowEdgeIds[i] = uint16(index);
+                }
+                unchecked {
+                    ++k;
+                }
+            }
+            unchecked {
+                ++i;
+            }
+        }
+        packedCoordinates = _packCoordinates(coords);
+    }
+
+    // Internal helpers
+
+    function _polishFuzzedTotalAmount(uint256 totalAmount) internal pure returns (uint256) {
+        totalAmount %= (MAX_TOTAL_AMOUNT + 1);
+        if (totalAmount < MIN_TOTAL_AMOUNT) totalAmount = MIN_TOTAL_AMOUNT;
+        return totalAmount;
+    }
+
+    function _polishFuzzedNumberOfTerminatedEdges(uint256 numberOfTerminatedEdges) internal pure returns (uint256) {
+        numberOfTerminatedEdges %= (MAX_TERMINATED_EDGES + 1);
+        if (numberOfTerminatedEdges < MIN_TERMINATED_EDGES) numberOfTerminatedEdges = MIN_TERMINATED_EDGES;
+        return numberOfTerminatedEdges;
+    }
+
+    function _setSourceState(address sourceAvatar, uint64 lastUpdatedDay, uint256 totalAmount) internal {
+        // make source approval to operate itself
+        _setOperatorApproval(sourceAvatar, sourceAvatar);
+        // register source as human
+        _registerHuman(sourceAvatar);
+        // set source balance of own id as totalAmount
+        _setCRCBalance(uint256(uint160(sourceAvatar)), sourceAvatar, lastUpdatedDay, uint192(totalAmount));
+    }
+
+    function _setEdgeState(
+        uint64 lastUpdatedDay,
+        address[] memory flowVertices,
+        uint256 flowAmount,
+        uint256 k,
+        uint256 index
+    ) internal {
+        address vertixFrom = k != 0 ? flowVertices[index] : flowVertices[0];
+        address vertixTo =
+            k != NUMBER_VERTICES_PER_FLOW ? flowVertices[index + 1] : flowVertices[flowVertices.length - 1];
+        // set balances
+        if (k != 0) _setCRCBalance(uint256(uint160(vertixFrom)), vertixFrom, lastUpdatedDay, uint192(flowAmount));
+        // set trust connection
+        _setTrust(vertixTo, vertixFrom);
+    }
+
+    function _generateFlowAmounts(uint256 totalAmount, uint256 numberOfTerminatedEdges)
+        internal
+        pure
+        returns (uint256[] memory flowAmounts)
+    {
+        uint256 unusedAmount = totalAmount;
+        flowAmounts = new uint256[](numberOfTerminatedEdges);
+        for (uint256 i; i < numberOfTerminatedEdges;) {
+            uint256 flowAmount = unusedAmount / numberOfTerminatedEdges;
+            if (i == numberOfTerminatedEdges - 1) flowAmount = unusedAmount;
+            flowAmounts[i] = flowAmount;
+            unusedAmount -= flowAmount;
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    /**
+     * @dev Packs `coords` (of length 3*E) into 6*E bytes:
+     *      for each triple (c0, c1, c2), produce c0(16 bits), c1(16 bits), c2(16 bits).
+     */
+    function _packCoordinates(uint16[] memory coords) internal pure returns (bytes memory) {
+        require(coords.length % 3 == 0, "Coords length must be multiple of 3");
+        uint256 edgeCount = coords.length / 3;
+        bytes memory result = new bytes(edgeCount * 6);
+
+        for (uint256 i = 0; i < edgeCount; i++) {
+            // 3 coords per edge
+            uint16 c0 = coords[3 * i + 0];
+            uint16 c1 = coords[3 * i + 1];
+            uint16 c2 = coords[3 * i + 2];
+
+            // Each coord => 2 bytes
+            // so offset is i*6
+            uint256 offset = i * 6;
+            result[offset + 0] = bytes1(uint8(c0 >> 8));
+            result[offset + 1] = bytes1(uint8(c0 & 0xFF));
+            result[offset + 2] = bytes1(uint8(c1 >> 8));
+            result[offset + 3] = bytes1(uint8(c1 & 0xFF));
+            result[offset + 4] = bytes1(uint8(c2 >> 8));
+            result[offset + 5] = bytes1(uint8(c2 & 0xFF));
+        }
+        return result;
+    }
+}

--- a/test/helpers/HubStorageWrites.sol
+++ b/test/helpers/HubStorageWrites.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.28;
+
+import "forge-std/Test.sol";
+
+contract HubStorageWrites is Test {
+    // Hub storage slots
+    uint256 internal constant DISCOUNTED_BALANCES_SLOT = 17;
+    uint256 internal constant OPERATOR_APPROVAL_SLOT = 19;
+    uint256 internal constant MINT_TIMES_SLOT = 21;
+    uint256 internal constant AVATARS_SLOT = 26;
+    uint256 internal constant TRUST_MARKERS_SLOT = 29;
+
+    // Hub address
+    /// @dev use constant, but in case of updates refactor into immutable
+    address internal constant HUB = 0xc12C1E50ABB450d6205Ea2C3Fa861b3B834d13e8;
+
+    // The address used as the first element of the linked list of avatars.
+    uint256 private constant SENTINEL = uint256(1);
+    bytes32 private constant MAX_EXPIRY = bytes32(uint256(type(uint96).max) << 160);
+    bytes32 private constant TRUE = bytes32(uint256(1));
+
+    /// @dev Sets Hub ERC1155 balance of id for account.
+    function _setCRCBalance(uint256 id, address account, uint64 lastUpdatedDay, uint192 balance) internal {
+        bytes32 idSlot = keccak256(abi.encodePacked(id, DISCOUNTED_BALANCES_SLOT));
+        bytes32 accountSlot = keccak256(abi.encodePacked(uint256(uint160(account)), idSlot));
+        uint256 discountedBalance = (uint256(lastUpdatedDay) << 192) + balance;
+        vm.store(HUB, accountSlot, bytes32(discountedBalance));
+    }
+
+    /// @dev Sets max expiry trust.
+    function _setTrust(address truster, address trusted) internal {
+        bytes32 trusterSlot = keccak256(abi.encodePacked(uint256(uint160(truster)), TRUST_MARKERS_SLOT));
+        bytes32 trustedSlot = keccak256(abi.encodePacked(uint256(uint160(trusted)), trusterSlot));
+        vm.store(HUB, trustedSlot, MAX_EXPIRY);
+    }
+
+    /// @dev Simulates human registration.
+    function _registerHuman(address account) internal {
+        _insertAvatar(account);
+        _setMintTime(account);
+    }
+
+    function _setOperatorApproval(address account, address operator) internal {
+        bytes32 accountSlot = keccak256(abi.encodePacked(uint256(uint160(account)), OPERATOR_APPROVAL_SLOT));
+        bytes32 operatorSlot = keccak256(abi.encodePacked(uint256(uint160(operator)), accountSlot));
+        vm.store(HUB, operatorSlot, TRUE);
+    }
+
+    /// @dev Sets Hub mint times for avatar.
+    function _insertAvatar(address avatar) internal {
+        // last and avatar slots
+        bytes32 lastAvatarSlot = keccak256(abi.encodePacked(SENTINEL, AVATARS_SLOT));
+        bytes32 newAvatarSlot = keccak256(abi.encodePacked(uint256(uint160(avatar)), AVATARS_SLOT));
+        // read last value
+        bytes32 lastAvatarValue = vm.load(HUB, lastAvatarSlot);
+        // write new value to last slot
+        vm.store(HUB, lastAvatarSlot, bytes32(uint256(uint160(avatar))));
+        // write last value to new slot
+        vm.store(HUB, newAvatarSlot, lastAvatarValue);
+    }
+
+    /// @dev Sets Hub mint times for avatar.
+    function _setMintTime(address avatar) internal {
+        bytes32 avatarSlot = keccak256(abi.encodePacked(uint256(uint160(avatar)), MINT_TIMES_SLOT));
+        uint256 mintTime = block.timestamp << 160;
+        vm.store(HUB, avatarSlot, bytes32(mintTime));
+    }
+}


### PR DESCRIPTION
This PR contents implementation of basic group mint/redemption test framework utilizing simple flow matrix generator.

Implemented:
- HubStorageWrites helper contract allows to set generic Hub state: including trust networks and human avatars balances. 
- FlowMatrixGenerator helper contract utilizes HubStorageWrites and allows to generate simple flow matrix (first attempt to implement generic solution, but due to insufficient time as a result: oversimplified and more mint specific, would be cool to continue work on it with intention to get more generic solution).
- CMGMintRedemptionFlowTest utilizes helper contracts and implements generic mint and redemption flow tests, but is used for CoreMembersGroup to have practical results of testing framework (later generic testing framework should be extracted from this testing specific group implementation and have simple connection to be used by any group implementation).

Additionally chatgpt was used to:
- get raw empty test template with some comments (chatgpt used fork mode on its own)
- get _packCoordinates and sortWithMapping function (not reviewed, but seems working as expected)

Required actions:
- in order to move from fork mode to mock mode Hub and StandardTreasury mocks should be implemented.
- implement one more redemption test case

Testing results for CoreMembersGroup:
- Group Mint via operateFlowMatrix (Single collateral) - passed.
- Batch Group Mint Flow (multiple collaterals) - passed.
- Redemption Flow - failed with error `CMGHandlerCouldNotFillRedemptionRequest()`, however vault holds requested collateral.